### PR TITLE
Fix href error in the footer

### DIFF
--- a/client/src/components/footer.jsx
+++ b/client/src/components/footer.jsx
@@ -23,7 +23,7 @@ const Footer = () => (
     </Container>
     <div className="text-center p-3 footer-lower">
       ©2023 Copyright{" | "}
-      <a href="#">unifinder.com</a> {" | "} All Rights Reserved.
+      <a href={() => false}>unifinder.com</a> {" | "} All Rights Reserved.
     </div>
   </footer>
 );


### PR DESCRIPTION
Small fix of this error showing in the console `The href attribute requires a valid value to be accessible`